### PR TITLE
build: build only the portable examples off Windows

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,9 @@
+# The windowed examples use the Win32 message pump in common/example_support.cpp and compile
+# their shaders with slangc, so they and the Slang tooling they need are Windows-only for now.
+if(NOT WIN32)
+    return()
+endif()
+
 include(NoGraphicsAPI_slang.cmake)
 
 add_library(NoGraphicsAPI_example_support STATIC


### PR DESCRIPTION
Enabling the examples on a non-Windows host fails at configure time: the Slang and SPIRV-Tools lookups in NoGraphicsAPI_slang.cmake are REQUIRED and ran unconditionally, and common/example_support.hpp refuses to compile anywhere but Windows.

The triangle, cube and deferred_renderer examples all need the Win32 message pump, so the whole windowed set and the shader tooling it depends on are now skipped elsewhere.