### PR TITLE
Change Slang version checking regex in cmake file

### DIFF
--- a/examples/NoGraphicsAPI_slang.cmake
+++ b/examples/NoGraphicsAPI_slang.cmake
@@ -24,7 +24,7 @@ endfunction()
 
 NoGraphicsAPI_require_tool_version(
     "${NOGRAPHICSAPI_SLANGC}" -version Slang 2026.14.1
-    "([0-9]+\\.[0-9]+\\.[0-9]+)")
+    "([0-9]+\\.[0-9]+(\\.[0-9]+)?)")
 NoGraphicsAPI_require_tool_version(
     "${NOGRAPHICSAPI_SPIRV_VAL}" --version SPIRV-Tools 2026.3
     "SPIRV-Tools v([0-9]+\\.[0-9]+)")


### PR DESCRIPTION
Change the regex to fix this version issue when using latest version of slang.

The error that occurs when building with cmake:

```
CMake Error at NoGraphicsAPI_slang.cmake:19 (message):
  NoGraphicsAPI examples require Slang 2026.14.1 or newer; found '2026.17' at
  C:/Software/slangc/slangc.exe
```

Issue already reported:
https://github.com/sebbbi/NoGraphicsAPI/issues/3