### PR TITLE
fix: no console on release build

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,3 +14,18 @@ endif()
 add_subdirectory(triangle)
 add_subdirectory(cube)
 add_subdirectory(deferred_renderer)
+
+function(NoGraphicsAPI_make_release_gui target)
+    if(WIN32)
+        set_target_properties(${target} PROPERTIES
+            WIN32_EXECUTABLE "$<$<CONFIG:Release>:TRUE>"
+        )
+        target_link_options(${target} PRIVATE
+            "$<$<CONFIG:Release>:/ENTRY:mainCRTStartup>"
+        )
+    endif()
+endfunction()
+
+NoGraphicsAPI_make_release_gui(example_triangle)
+NoGraphicsAPI_make_release_gui(example_cube)
+NoGraphicsAPI_make_release_gui(example_deferred_renderer)


### PR DESCRIPTION
Release example builds opened a console window alongside the Vulkan
window. Set WIN32_EXECUTABLE for Release so Windows does not create a
console, and add /ENTRY:mainCRTStartup because the examples define
main() rather than WinMain(). Debug builds keep the console subsystem
so startup and device errors printed to stderr stay visible.