### PR TITLE
Remove unused STORAGE_BUFFER usage

### DIFF
--- a/src/NoGraphicsAPI.cpp
+++ b/src/NoGraphicsAPI.cpp
@@ -410,7 +410,7 @@ VkAccessFlags2 to_vk(Access accesses)
 }
 
 constexpr VkBufferUsageFlags universal_buffer_usage =
-    VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+    VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
     VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT |
     VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
@@ -434,8 +434,7 @@ bool is_usable_memory_type(const VkPhysicalDeviceMemoryProperties& properties, u
 }
 
 constexpr VkAddressCommandFlagsKHR address_flags =
-    VK_ADDRESS_COMMAND_FULLY_BOUND_BIT_KHR |
-    VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR;
+    VK_ADDRESS_COMMAND_FULLY_BOUND_BIT_KHR;
 } // namespace
 
 namespace detail


### PR DESCRIPTION
`VK_BUFFER_USAGE_STORAGE_BUFFER_BIT` specifically allows the _creation of storage buffer descriptors_. We don't use those here.
This also happen to pull in an unnecessary 16-byte alignment requirement on Nvidia.

Note that the validation error introduced by this PR is a VVL bug that I [reported](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/13040):
```
vkCmdCopyMemoryToImageKHR(): pCopyMemoryInfo->pRegions[0].addressRange.address (0xfd20290) belongs to VkBuffer 0x230000000023, which was created with VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT, but address flags (VK_ADDRESS_COMMAND_FULLY_BOUND_BIT_KHR) do not contain VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR or VK_ADDRESS_COMMAND_UNKNOWN_STORAGE_BUFFER_USAGE_BIT_KHR.
The Vulkan spec states: If any buffer, which is bound to a range of VkDeviceMemory that overlaps the range backing addressRange, was created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, addressFlags must include VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR or VK_ADDRESS_COMMAND_UNKNOWN_STORAGE_BUFFER_USAGE_BIT_KHR (https://docs.vulkan.org/spec/latest/chapters/copies.html#VUID-VkDeviceMemoryImageCopyKHR-addressRange-13122)
```