### PR TITLE
fix: make example assets distributable

### DIFF
--- a/examples/cube/CMakeLists.txt
+++ b/examples/cube/CMakeLists.txt
@@ -28,7 +28,12 @@ NoGraphicsAPI_add_example(example_cube
 )
 target_link_libraries(example_cube PRIVATE NoGraphicsAPIUtility::math NoGraphicsAPIUtility::textures)
 target_compile_definitions(example_cube PRIVATE
-    NOGRAPHICSAPI_CUBE_VERTEX_SPV_PATH="${vertex_spv}"
-    NOGRAPHICSAPI_CUBE_FRAGMENT_SPV_PATH="${fragment_spv}"
-    NOGRAPHICSAPI_CUBE_TEXTURE_PATH="${texture}"
+    NOGRAPHICSAPI_CUBE_VERTEX_SPV_PATH="shaders/cube.vert.spv"
+    NOGRAPHICSAPI_CUBE_FRAGMENT_SPV_PATH="shaders/cube.frag.spv"
+    NOGRAPHICSAPI_CUBE_TEXTURE_PATH="${texture_name}"
 )
+if(CMAKE_CONFIGURATION_TYPES)
+    add_custom_command(TARGET example_cube POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${shader_dir} $<TARGET_FILE_DIR:example_cube>/shaders
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${texture} $<TARGET_FILE_DIR:example_cube>/${texture_name})
+endif()

--- a/examples/deferred_renderer/CMakeLists.txt
+++ b/examples/deferred_renderer/CMakeLists.txt
@@ -42,9 +42,13 @@ NoGraphicsAPI_add_example(example_deferred_renderer
 )
 target_link_libraries(example_deferred_renderer PRIVATE NoGraphicsAPIUtility::math NoGraphicsAPIUtility::textures)
 target_compile_definitions(example_deferred_renderer PRIVATE
-    NOGRAPHICSAPI_SIMULATION_COMPUTE_SPV_PATH="${simulation_compute_spv}"
-    NOGRAPHICSAPI_GBUFFER_MESH_SPV_PATH="${gbuffer_mesh_spv}"
-    NOGRAPHICSAPI_GBUFFER_FRAGMENT_SPV_PATH="${gbuffer_fragment_spv}"
-    NOGRAPHICSAPI_DEFERRED_VERTEX_SPV_PATH="${deferred_vertex_spv}"
-    NOGRAPHICSAPI_DEFERRED_FRAGMENT_SPV_PATH="${deferred_fragment_spv}"
+    NOGRAPHICSAPI_SIMULATION_COMPUTE_SPV_PATH="shaders/simulation.comp.spv"
+    NOGRAPHICSAPI_GBUFFER_MESH_SPV_PATH="shaders/gbuffer.mesh.spv"
+    NOGRAPHICSAPI_GBUFFER_FRAGMENT_SPV_PATH="shaders/gbuffer.frag.spv"
+    NOGRAPHICSAPI_DEFERRED_VERTEX_SPV_PATH="shaders/deferred.vert.spv"
+    NOGRAPHICSAPI_DEFERRED_FRAGMENT_SPV_PATH="shaders/deferred.frag.spv"
 )
+if(CMAKE_CONFIGURATION_TYPES)
+    add_custom_command(TARGET example_deferred_renderer POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${shader_dir} $<TARGET_FILE_DIR:example_deferred_renderer>/shaders)
+endif()

--- a/examples/triangle/CMakeLists.txt
+++ b/examples/triangle/CMakeLists.txt
@@ -13,6 +13,10 @@ NoGraphicsAPI_add_example(example_triangle
     ${fragment_spv}
 )
 target_compile_definitions(example_triangle PRIVATE
-    NOGRAPHICSAPI_VERTEX_SPV_PATH="${vertex_spv}"
-    NOGRAPHICSAPI_FRAGMENT_SPV_PATH="${fragment_spv}"
+    NOGRAPHICSAPI_VERTEX_SPV_PATH="shaders/triangle.vert.spv"
+    NOGRAPHICSAPI_FRAGMENT_SPV_PATH="shaders/triangle.frag.spv"
 )
+if(CMAKE_CONFIGURATION_TYPES)
+    add_custom_command(TARGET example_triangle POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${shader_dir} $<TARGET_FILE_DIR:example_triangle>/shaders)
+endif()


### PR DESCRIPTION
## Summary

- Use relative runtime paths for example shaders and textures
- Place runtime assets beside configuration-specific executable outputs
- Allow example binaries and their assets to be distributed without the build tree

## Motivation

The example binaries previously embedded absolute build-directory paths for runtime assets. As a result, distributed binaries still depended on files at their original build locations.

## Validation

- Built all examples in Debug and Release configurations
- Verified the examples start and load their runtime assets
- Verified the binaries no longer embed absolute runtime asset paths