### PR TITLE
Allow Slang 2026.13.1 from Vulkan SDK 1.4.357

### DIFF
--- a/examples/NoGraphicsAPI_slang.cmake
+++ b/examples/NoGraphicsAPI_slang.cmake
@@ -23,7 +23,7 @@ function(NoGraphicsAPI_require_tool_version program argument name minimum patter
 endfunction()
 
 NoGraphicsAPI_require_tool_version(
-    "${NOGRAPHICSAPI_SLANGC}" -version Slang 2026.14.1
+    "${NOGRAPHICSAPI_SLANGC}" -version Slang 2026.13.1
     "([0-9]+\\.[0-9]+(\\.[0-9]+)?)")
 NoGraphicsAPI_require_tool_version(
     "${NOGRAPHICSAPI_SPIRV_VAL}" --version SPIRV-Tools 2026.3


### PR DESCRIPTION
The LunarG Vulkan SDK 1.4.357 installer packages Slang 2026.13.1, causing CMake configuration of the examples to fail out-of-the-box:

```
CMake Error at examples/NoGraphicsAPI_slang.cmake:19 (message):
  NoGraphicsAPI examples require Slang 2026.14.1 or newer; found '2026.13.1-...'
```

Relax the tool version floor to 2026.13.1.

Verified on Windows 11 with Vulkan SDK 1.4.357: all 8 shader stages across `triangle`, `cube`, and `deferred_renderer` compile and pass `spirv-val --target-env vulkan1.4 --scalar-block-layout`.