### PR TITLE
feat: add device information diagnostics

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 add_subdirectory(triangle)
 add_subdirectory(cube)
 add_subdirectory(deferred_renderer)
+add_subdirectory(device_info)
 
 function(NoGraphicsAPI_make_release_gui target)
     if(WIN32)

--- a/examples/cube/cube.cpp
+++ b/examples/cube/cube.cpp
@@ -85,7 +85,7 @@ int main() {
     }
 
 	const DeviceCaps& caps = get_device_caps(device);
-    printf("Using %s\n", caps.device_name);
+	printf("Using %s\n", get_device_info(device).device_name);
 
 	// Shaders
     const Span<uint32> vertex_spirv = read_spirv(NOGRAPHICSAPI_CUBE_VERTEX_SPV_PATH);

--- a/examples/deferred_renderer/deferred_renderer.cpp
+++ b/examples/deferred_renderer/deferred_renderer.cpp
@@ -161,7 +161,7 @@ int main()
     }
 
     const DeviceCaps& caps = get_device_caps(device);
-    printf("Using %s\n", caps.device_name);
+    printf("Using %s\n", get_device_info(device).device_name);
 
     // Shaders
     const Span<uint32> simulation_spirv = read_spirv(NOGRAPHICSAPI_SIMULATION_COMPUTE_SPV_PATH);

--- a/examples/device_info/CMakeLists.txt
+++ b/examples/device_info/CMakeLists.txt
@@ -1,0 +1,3 @@
+NoGraphicsAPI_add_example(example_device_info
+	device_info.cpp
+)

--- a/examples/device_info/device_info.cpp
+++ b/examples/device_info/device_info.cpp
@@ -1,0 +1,91 @@
+// Creates a headless device and reports its Vulkan identity, memory information, and operational
+// limits and features exposed through NoGraphicsAPI.
+
+#include <NoGraphicsAPI/NoGraphicsAPI.hpp>
+
+#include <inttypes.h>
+#include <stdio.h>
+
+const char* device_type_name(uint32 device_type)
+{
+    switch (device_type)
+    {
+    case 0: return "other";
+    case 1: return "integrated GPU";
+    case 2: return "discrete GPU";
+    case 3: return "virtual GPU";
+    case 4: return "CPU";
+    default: return "unknown";
+    }
+}
+
+void print_bytes(const char* label, uint64 bytes)
+{
+    if (bytes > 1024ull * 1024ull * 1024ull)
+        printf("%-26s%" PRIu64 " bytes (%.2f GiB)\n", label, bytes, static_cast<double>(bytes) / (1024.0 * 1024.0 * 1024.0));
+    else if (bytes > 1024ull * 1024ull)
+        printf("%-26s%" PRIu64 " bytes (%.2f MiB)\n", label, bytes, static_cast<double>(bytes) / (1024.0 * 1024.0));
+    else if (bytes > 1024ull)
+        printf("%-26s%" PRIu64 " bytes (%.2f KiB)\n", label, bytes, static_cast<double>(bytes) / 1024.0);
+    else
+        printf("%-26s%" PRIu64 " bytes\n", label, bytes);
+}
+
+int main()
+{
+    const gpu::DeviceInit device_init = gpu::create_device();
+    if (device_init.error != gpu::Error::none)
+    {
+        const char* reason = "unknown";
+        switch (device_init.error)
+        {
+        case gpu::Error::none: break;
+        case gpu::Error::unsupported: reason = "unsupported: no device exposes every required extension and feature"; break;
+        case gpu::Error::device_lost: reason = "device lost"; break;
+        case gpu::Error::driver_error: reason = "driver error"; break;
+        }
+        printf("create_device failed: %s\n", reason);
+        return 1;
+    }
+
+    const gpu::DeviceInfo& info = gpu::get_device_info(device_init.device);
+    const gpu::DeviceMemoryInfo& memory = gpu::get_device_memory_info(device_init.device);
+    const gpu::DeviceCaps& caps = gpu::get_device_caps(device_init.device);
+    printf(
+        "Vulkan API                0x%08" PRIx32 " (%" PRIu32 ".%" PRIu32 ".%" PRIu32 ")\n",
+        info.api_version,
+        info.api_version >> 22u,
+        (info.api_version >> 12u) & 0x3ffu,
+        info.api_version & 0xfffu
+    );
+    printf("device                    %s\n", info.device_name);
+    printf("vendor id                 0x%04" PRIx32 "\n", info.vendor_id);
+    printf("device id                 0x%04" PRIx32 "\n", info.device_id);
+    printf("device type               %" PRIu32 " (%s)\n", info.device_type, device_type_name(info.device_type));
+    printf("driver                    %s\n", info.driver_name);
+    printf("driver info               %s\n", info.driver_info);
+    printf("driver version            0x%08" PRIx32 "\n", info.driver_version);
+    print_bytes("max push data size", caps.max_push_data_size);
+    print_bytes("texture heap alignment", caps.texture_heap_alignment);
+    print_bytes("texture descriptor size", caps.texture_descriptor_size);
+    print_bytes("sampler descriptor size", caps.sampler_descriptor_size);
+    print_bytes("image descriptor align", caps.image_descriptor_alignment);
+    print_bytes("sampler descriptor align", caps.sampler_descriptor_alignment);
+    print_bytes("resource heap alignment", caps.resource_heap_alignment);
+    print_bytes("sampler heap alignment", caps.sampler_heap_alignment);
+    print_bytes("min resource heap range", caps.min_resource_heap_reserved_range);
+    print_bytes("min sampler heap range", caps.min_sampler_heap_reserved_range);
+    print_bytes("device-local memory", memory.device_local_memory_size);
+    print_bytes("host-visible memory", memory.host_visible_memory_size);
+    print_bytes("host-visible device-local", memory.host_visible_device_local_memory_size);
+    printf("BC texture compression    %s\n", caps.texture_compression_bc ? "yes" : "no");
+    printf("ASTC texture compression  %s\n", caps.texture_compression_astc ? "yes" : "no");
+    printf("ETC2 texture compression  %s\n", caps.texture_compression_etc2 ? "yes" : "no");
+    printf("16-bit storage in/out     %s\n", caps.storage_input_output16 ? "yes" : "no");
+    printf("unified image layouts     %s\n", caps.unified_image_layouts ? "yes" : "no");
+    printf("swapchain maintenance 1   %s\n", caps.swapchain_maintenance1 ? "yes" : "no");
+
+    gpu::wait_idle(device_init.device);
+    gpu::destroy_device(device_init.device);
+    return 0;
+}

--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -20,7 +20,7 @@ int main()
         return 1;
     }
 
-    printf("Using %s\n", get_device_caps(device).device_name);
+    printf("Using %s\n", get_device_info(device).device_name);
 
     const Span<uint32> vertex_spirv = read_spirv(NOGRAPHICSAPI_VERTEX_SPV_PATH);
     const Span<uint32> fragment_spirv = read_spirv(NOGRAPHICSAPI_FRAGMENT_SPV_PATH);

--- a/include/NoGraphicsAPI/NoGraphicsAPI.hpp
+++ b/include/NoGraphicsAPI/NoGraphicsAPI.hpp
@@ -424,19 +424,46 @@ constexpr Access operator|(Access lhs, Access rhs) noexcept
     return static_cast<Access>(static_cast<uint64>(lhs) | static_cast<uint64>(rhs));
 }
 
-struct DeviceCaps
+struct DeviceInfo
 {
     const char* device_name = nullptr;
+    const char* driver_name = nullptr;
+    const char* driver_info = nullptr;
+    uint32 vendor_id = 0;
+    uint32 device_id = 0;
+    uint32 device_type = 0;
+    uint32 api_version = 0;
+    uint32 driver_version = 0;
+};
+
+struct DeviceMemoryInfo
+{
+    uint64 device_local_memory_size = 0;
+    uint64 host_visible_memory_size = 0;
+    uint64 host_visible_device_local_memory_size = 0;
+};
+
+struct DeviceCaps
+{
     uint64 max_push_data_size = 0;
     // Common element size for suballocating TextureHeap storage; every SizeAlign::align divides this value.
     uint64 texture_heap_alignment = 0;
     uint64 texture_descriptor_size = 0; // Bytes per descriptor slot.
     uint64 sampler_descriptor_size = 0; // Bytes per descriptor slot.
+    uint64 image_descriptor_alignment = 0;
+    uint64 sampler_descriptor_alignment = 0;
+    uint64 resource_heap_alignment = 0;
+    uint64 sampler_heap_alignment = 0;
+    uint64 min_resource_heap_reserved_range = 0;
+    uint64 min_sampler_heap_reserved_range = 0;
     float timestamp_period_ns = 0.0f; // Nanoseconds per timestamp tick.
     uint32 sub_texel_precision_bits = 0; // Fractional filtering precision, for conservative sampled-field bounds.
     bool texture_compression_bc = false;
     bool texture_compression_astc = false;
+    bool texture_compression_etc2 = false;
     bool storage_input_output16 = false;
+    bool unified_image_layouts = false;
+    bool swapchain_maintenance1 = false;
 };
 
 // A windowed device and every call using it must remain on the native
@@ -645,6 +672,8 @@ struct RenderingDesc
 // Wait for all submitted frames to drain before destroying the device.
 [[nodiscard]] DeviceInit create_device(const DeviceDesc& desc = {}) noexcept;
 void destroy_device(Device* device) noexcept;
+[[nodiscard]] const DeviceInfo& get_device_info(const Device* device) noexcept;
+[[nodiscard]] const DeviceMemoryInfo& get_device_memory_info(const Device* device) noexcept;
 [[nodiscard]] const DeviceCaps& get_device_caps(const Device* device) noexcept;
 [[nodiscard]] bool supports_texture_format(const Device* device, Format format, TextureUsage usage) noexcept;
 [[nodiscard]] uint32x2 get_drawable_extent(Device* device) noexcept;

--- a/src/NoGraphicsAPI.cpp
+++ b/src/NoGraphicsAPI.cpp
@@ -650,11 +650,14 @@ struct Device
     uint32 timestamp_query_count = 0;
     VkPhysicalDeviceMemoryProperties memory_properties{};
     VkPhysicalDeviceProperties physical_properties{};
+    VkPhysicalDeviceDriverProperties driver_properties{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES};
     VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_properties{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_PROPERTIES_EXT};
     uint64 max_timeline_value_difference = 0;
     uint64 texture_heap_alignment = 16;
     uint32 texture_memory_type = VK_MAX_MEMORY_TYPES;
     detail::DeviceFunctions fn;
+    DeviceInfo info;
+    DeviceMemoryInfo memory_info;
     DeviceCaps caps;
     VkFormatFeatureFlags2 format_features[format_count]{};
     bool texture_compression_etc2 = false;
@@ -1580,6 +1583,7 @@ struct Candidate
     bool khr_swapchain_maintenance1 = false;
     VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_properties{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_PROPERTIES_EXT};
     VkPhysicalDeviceVulkan12Properties vulkan12_properties{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES};
+    VkPhysicalDeviceDriverProperties driver_properties{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES};
 };
 
 Error inspect_candidate(VkPhysicalDevice physical_device, VkSurfaceKHR surface, bool khr_surface_maintenance1, bool ext_surface_maintenance1,
@@ -1619,6 +1623,7 @@ Error inspect_candidate(VkPhysicalDevice physical_device, VkSurfaceKHR surface, 
         .physical_device = physical_device,
     };
     result.heap_properties.pNext = &result.vulkan12_properties;
+    result.vulkan12_properties.pNext = &result.driver_properties;
     VkPhysicalDeviceProperties2 properties2{
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
         .pNext = &result.heap_properties,
@@ -1627,6 +1632,7 @@ Error inspect_candidate(VkPhysicalDevice physical_device, VkSurfaceKHR surface, 
     result.properties = properties2.properties;
     result.heap_properties.pNext = nullptr;
     result.vulkan12_properties.pNext = nullptr;
+    result.driver_properties.pNext = nullptr;
     if (result.properties.apiVersion < VK_API_VERSION_1_4)
         return Error::unsupported;
 
@@ -1902,6 +1908,7 @@ DeviceInit create_device(const DeviceDesc& desc) noexcept
     state->physical_device = selected.physical_device;
     state->queue_family = selected.queue_family;
     state->physical_properties = selected.properties;
+    state->driver_properties = selected.driver_properties;
     state->heap_properties = selected.heap_properties;
     state->max_timeline_value_difference = selected.vulkan12_properties.maxTimelineSemaphoreValueDifference;
     state->heap_properties.pNext = nullptr;
@@ -2025,17 +2032,64 @@ DeviceInit create_device(const DeviceDesc& desc) noexcept
             return fail_device_creation(state, error);
     }
 
-    state->caps = {
+    uint64 device_local_memory_size = 0;
+    uint64 host_visible_memory_size = 0;
+    uint64 host_visible_device_local_memory_size = 0;
+    for (uint32 heap_index = 0; heap_index < state->memory_properties.memoryHeapCount; ++heap_index)
+    {
+        bool host_visible = false;
+        for (uint32 type_index = 0; type_index < state->memory_properties.memoryTypeCount; ++type_index)
+        {
+            const VkMemoryType& memory_type = state->memory_properties.memoryTypes[type_index];
+            if (memory_type.heapIndex == heap_index && (memory_type.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0)
+            {
+                host_visible = true;
+                break;
+            }
+        }
+        const uint64 heap_size = state->memory_properties.memoryHeaps[heap_index].size;
+        const bool device_local = (state->memory_properties.memoryHeaps[heap_index].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0;
+        if (device_local)
+            device_local_memory_size += heap_size;
+        if (host_visible)
+            host_visible_memory_size += heap_size;
+        if (device_local && host_visible)
+            host_visible_device_local_memory_size += heap_size;
+    }
+    state->info = {
         .device_name = state->physical_properties.deviceName,
+        .driver_name = state->driver_properties.driverName,
+        .driver_info = state->driver_properties.driverInfo,
+        .vendor_id = state->physical_properties.vendorID,
+        .device_id = state->physical_properties.deviceID,
+        .device_type = static_cast<uint32>(state->physical_properties.deviceType),
+        .api_version = state->physical_properties.apiVersion,
+        .driver_version = state->physical_properties.driverVersion,
+    };
+    state->memory_info = {
+        .device_local_memory_size = device_local_memory_size,
+        .host_visible_memory_size = host_visible_memory_size,
+        .host_visible_device_local_memory_size = host_visible_device_local_memory_size,
+    };
+    state->caps = {
         .max_push_data_size = state->heap_properties.maxPushDataSize,
         .texture_heap_alignment = state->texture_heap_alignment,
         .texture_descriptor_size = state->heap_properties.imageDescriptorSize,
         .sampler_descriptor_size = state->heap_properties.samplerDescriptorSize,
+        .image_descriptor_alignment = state->heap_properties.imageDescriptorAlignment,
+        .sampler_descriptor_alignment = state->heap_properties.samplerDescriptorAlignment,
+        .resource_heap_alignment = state->heap_properties.resourceHeapAlignment,
+        .sampler_heap_alignment = state->heap_properties.samplerHeapAlignment,
+        .min_resource_heap_reserved_range = state->heap_properties.minResourceHeapReservedRange,
+        .min_sampler_heap_reserved_range = state->heap_properties.minSamplerHeapReservedRange,
         .timestamp_period_ns = selected.properties.limits.timestampPeriod,
         .sub_texel_precision_bits = selected.properties.limits.subTexelPrecisionBits,
         .texture_compression_bc = selected.texture_compression_bc,
         .texture_compression_astc = selected.texture_compression_astc,
+        .texture_compression_etc2 = selected.texture_compression_etc2,
         .storage_input_output16 = selected.storage_input_output16,
+        .unified_image_layouts = selected.unified_image_layouts,
+        .swapchain_maintenance1 = selected.khr_swapchain_maintenance1,
     };
     if (presentation)
     {
@@ -3227,6 +3281,18 @@ void wait_idle(Device* device) noexcept
     assert(!device->acquired_swapchain && "wait_idle is not allowed while a swapchain image is acquired");
     device->drain_contexts();
     device->next_present_context = 0;
+}
+
+const DeviceInfo& get_device_info(const Device* device) noexcept
+{
+    assert(device && "get_device_info called with a null device");
+    return device->info;
+}
+
+const DeviceMemoryInfo& get_device_memory_info(const Device* device) noexcept
+{
+    assert(device && "get_device_memory_info called with a null device");
+    return device->memory_info;
 }
 
 const DeviceCaps& get_device_caps(const Device* device) noexcept

--- a/tests/api_test.cpp
+++ b/tests/api_test.cpp
@@ -338,7 +338,7 @@ static_assert(sizeof(gpu::TimelinePoint) == 16 && offsetof(gpu::TimelinePoint, s
               offsetof(gpu::TimelinePoint, value) == 8);
 
 constexpr gpu::DeviceCaps default_caps{};
-static_assert(default_caps.device_name == nullptr && default_caps.max_push_data_size == 0 &&
+    static_assert(default_caps.max_push_data_size == 0 &&
               default_caps.texture_heap_alignment == 0 &&
               default_caps.texture_descriptor_size == 0 &&
               default_caps.sampler_descriptor_size == 0 && !default_caps.texture_compression_bc &&


### PR DESCRIPTION
## Motivation

NoGraphicsAPI selects a Vulkan device by requiring a specific set of extensions, features, and memory properties. When device creation succeeds, applications have no convenient way to see which device was selected or which limits and capabilities shaped the backend configuration.

This makes it difficult to:

- Verify that the expected GPU and driver were selected.
- Understand descriptor-heap and texture-placement limits.
- Inspect the memory available to the backend's supported allocation paths.

The new headless diagnostic example provides this visibility without turning NoGraphicsAPI into a general Vulkan inspection tool.

## Summary

- Add a headless `device_info` example for reporting the selected Vulkan device.
- Expose device identity through `DeviceInfo` and `get_device_info()`.
- Expose memory totals through `DeviceMemoryInfo` and `get_device_memory_info()`.
- Keep operational limits and feature support in `DeviceCaps`.
- Update existing examples to use the new device-info endpoint for device names.
- Add the device-info target to the CMake build.
- Format device types and byte values for readable diagnostics.

## Validation

- `cmake --build build-msvc --config Debug --target ALL_BUILD`
- `cmake --build --preset msvc-release`
- All configured tests pass: 7 passed, 0 failed.